### PR TITLE
Prevent WIP comment saving

### DIFF
--- a/src/__fixtures__/state.tsx
+++ b/src/__fixtures__/state.tsx
@@ -8,7 +8,7 @@ const remoteReply: CommentReply = {
   author: { id: 1, name: 'test user' },
   date: 0,
   text: 'a reply',
-  editPreviousText: '',
+  newText: '',
   deleted: false,
 };
 
@@ -19,7 +19,7 @@ const localReply: CommentReply = {
   author: { id: 1, name: 'test user' },
   date: 0,
   text: 'another reply',
-  editPreviousText: '',
+  newText: '',
   deleted: false,
 };
 
@@ -34,7 +34,7 @@ const remoteComment: Comment = {
   date: 0,
   text: 'test text',
   newReply: '',
-  editPreviousText: '',
+  newText: '',
   remoteReplyCount: 1,
   replies: new Map([[remoteReply.localId, remoteReply], [localReply.localId, localReply]]),
 };
@@ -50,7 +50,7 @@ const localComment: Comment = {
   date: 0,
   text: 'unsaved comment',
   newReply: '',
-  editPreviousText: '',
+  newText: '',
   replies: new Map(),
   remoteReplyCount: 0,
 };

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../actions/comments';
 import { LayoutController } from '../../utils/layout';
 import { getNextReplyId } from '../../utils/sequences';
-import CommentReplyComponent, { saveCommentReply } from '../CommentReply';
+import CommentReplyComponent from '../CommentReply';
 import type { TranslatableStrings } from '../../main';
 
 async function saveComment(comment: Comment, store: Store) {
@@ -27,6 +27,7 @@ async function saveComment(comment: Comment, store: Store) {
     store.dispatch(
       updateComment(comment.localId, {
         mode: 'default',
+        text: comment.newText,
         remoteId: comment.remoteId,
         author: comment.author,
         date: comment.date,
@@ -112,7 +113,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       const replyId = getNextReplyId();
       const reply = newCommentReply(replyId, null, Date.now(), {
         text: comment.newReply,
-        mode: 'saving',
+        mode: 'default',
       });
       store.dispatch(addReply(comment.localId, reply));
 
@@ -121,8 +122,6 @@ export default class CommentComponent extends React.Component<CommentProps> {
           newReply: '',
         })
       );
-
-      await saveCommentReply(comment, reply, store);
     };
 
     const onClickCancelReply = (e: React.MouseEvent) => {
@@ -212,7 +211,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
 
       store.dispatch(
         updateComment(comment.localId, {
-          text: e.target.value,
+          newText: e.target.value,
         })
       );
     };
@@ -237,7 +236,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
         <form onSubmit={onSave}>
           <textarea
             className="comment__input"
-            value={comment.text}
+            value={comment.newText}
             onChange={onChangeText}
             style={{ resize: 'none' }}
             placeholder="Enter your comments..."
@@ -270,7 +269,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
 
       store.dispatch(
         updateComment(comment.localId, {
-          text: e.target.value,
+          newText: e.target.value,
         })
       );
     };
@@ -287,7 +286,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       store.dispatch(
         updateComment(comment.localId, {
           mode: 'default',
-          text: comment.editPreviousText,
+          newText: comment.text,
         })
       );
     };
@@ -297,7 +296,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
         <form onSubmit={onSave}>
           <textarea
             className="comment__input"
-            value={comment.text}
+            value={comment.newText}
             onChange={onChangeText}
             style={{ resize: 'none' }}
           />
@@ -475,7 +474,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       store.dispatch(
         updateComment(comment.localId, {
           mode: 'editing',
-          editPreviousText: comment.text,
+          newText: comment.text,
         })
       );
     };

--- a/src/components/CommentReply/index.tsx
+++ b/src/components/CommentReply/index.tsx
@@ -21,6 +21,7 @@ export async function saveCommentReply(
     store.dispatch(
       updateReply(comment.localId, reply.localId, {
         mode: 'default',
+        text: reply.newText,
         author: reply.author,
       })
     );
@@ -85,7 +86,7 @@ export default class CommentReplyComponent extends React.Component<CommentReplyP
 
       store.dispatch(
         updateReply(comment.localId, reply.localId, {
-          text: e.target.value,
+          newText: e.target.value,
         })
       );
     };
@@ -101,7 +102,7 @@ export default class CommentReplyComponent extends React.Component<CommentReplyP
       store.dispatch(
         updateReply(comment.localId, reply.localId, {
           mode: 'default',
-          text: reply.editPreviousText,
+          newText: reply.text,
         })
       );
     };
@@ -110,7 +111,7 @@ export default class CommentReplyComponent extends React.Component<CommentReplyP
       <form onSubmit={onSave}>
         <textarea
           className="comment-reply__input"
-          value={reply.text}
+          value={reply.newText}
           onChange={onChangeText}
           style={{ resize: 'none' }}
         />
@@ -281,7 +282,7 @@ export default class CommentReplyComponent extends React.Component<CommentReplyP
       store.dispatch(
         updateReply(comment.localId, reply.localId, {
           mode: 'editing',
-          editPreviousText: reply.text,
+          newText: reply.text,
         })
       );
     };

--- a/src/state/comments.test.ts
+++ b/src/state/comments.test.ts
@@ -30,7 +30,7 @@ test('New comment added to state', () => {
     date: 0,
     text: 'new comment',
     newReply: '',
-    editPreviousText: '',
+    newText: '',
     remoteReplyCount: 0,
     replies: new Map(),
   };
@@ -54,7 +54,7 @@ test('Remote comment added to state', () => {
     date: 0,
     text: 'new comment',
     newReply: '',
-    editPreviousText: '',
+    newText: '',
     remoteReplyCount: 0,
     replies: new Map(),
   };
@@ -108,7 +108,7 @@ test('Reply added', () => {
     author: { id: 1, name: 'test user' },
     date: 0,
     text: 'a new reply',
-    editPreviousText: '',
+    newText: '',
     deleted: false,
   };
   const addAction = actions.addReply(1, reply);
@@ -125,7 +125,7 @@ test('Remote reply added', () => {
     author: { id: 1, name: 'test user' },
     date: 0,
     text: 'a new reply',
-    editPreviousText: '',
+    newText: '',
     deleted: false,
   };
   const addAction = actions.addReply(1, reply);

--- a/src/state/comments.ts
+++ b/src/state/comments.ts
@@ -24,7 +24,7 @@ export interface CommentReply {
   author: Author | null;
   date: number;
   text: string;
-  editPreviousText: string;
+  newText: string;
   deleted: boolean;
 }
 
@@ -51,7 +51,7 @@ export function newCommentReply(
     author,
     date,
     text,
-    editPreviousText: '',
+    newText: '',
     deleted: false,
   };
 }
@@ -81,7 +81,7 @@ export interface Comment {
   text: string;
   replies: Map<number, CommentReply>;
   newReply: string;
-  editPreviousText: string;
+  newText: string;
   remoteReplyCount: number;
 }
 
@@ -116,7 +116,7 @@ export function newComment(
     text,
     replies,
     newReply: '',
-    editPreviousText: '',
+    newText: '',
     deleted: false,
     remoteReplyCount: Array.from(replies.values()).reduce(
       (n, reply) => (reply.remoteId !== null ? n + 1 : n),


### PR DESCRIPTION
Rework the editing/creating states to use a `newText` property, rather than writing directly to the comment's `text` and thus risking saving WIP comments to the db before the `save` button on the comment itself is clicked.